### PR TITLE
Фикс кодировки

### DIFF
--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -6,6 +6,8 @@ $mtime = $mtime[1] + $mtime[0];
 $tstart = $mtime;
 set_time_limit(0);
 
+header('Content-Type:text/html;charset=utf-8');
+
 require_once 'build.config.php';
 // Refresh model
 if (file_exists('build.model.php')) {


### PR DESCRIPTION
Чтобы, когда вызываешь напрямую в браузере build.transport.php не было кракозябр в сообщениях, которые выдает сам MODX:
"Создан новый пакет с подписью", "Зарегистрировано пространство имён пакета" и т.п.
