### PR TITLE
Update resolve.tables.php

### DIFF
--- a/_build/resolvers/resolve.tables.php
+++ b/_build/resolvers/resolve.tables.php
@@ -16,8 +16,8 @@ if ($object->xpdo) {
             if (is_file($schemaFile)) {
                 $schema = new SimpleXMLElement($schemaFile, 0, true);
                 if (isset($schema->object)) {
-                    foreach ($schema->object as $object) {
-                        $objects[] = (string)$object['class'];
+                    foreach ($schema->object as $obj) {
+                        $objects[] = (string)$obj['class'];
                     }
                 }
                 unset($schema);
@@ -86,8 +86,8 @@ if ($object->xpdo) {
             if (is_file($schemaFile)) {
                 $schema = new SimpleXMLElement($schemaFile, 0, true);
                 if (isset($schema->object)) {
-                    foreach ($schema->object as $object) {
-                        $objects[] = (string)$object['class'];
+                    foreach ($schema->object as $obj) {
+                        $objects[] = (string)$obj['class'];
                     }
                 }
                 unset($schema);


### PR DESCRIPTION
Поправлен баг со сбросом $object для последующих ресолверов. Он переопределялся на SimpleXMLElement из-за foreach($schema->object as $object) на 19 строчке.