### PR TITLE
Update modextraitem.map.inc.php

### DIFF
--- a/core/components/modextra/model/modextra/mysql/modextraitem.map.inc.php
+++ b/core/components/modextra/model/modextra/mysql/modextraitem.map.inc.php
@@ -27,7 +27,7 @@ $xpdo_meta_map['modExtraItem']= array (
     'description' => 
     array (
       'dbtype' => 'text',
-      'phptype' => 'text',
+      'phptype' => 'string',
       'null' => true,
       'default' => '',
     ),


### PR DESCRIPTION
Заметил что для работы на версии 2.7.0 нужно указать phptype string для description в противном случае в поле можно писать только числа текст не сохраняется