### PR TITLE
Adding access settings

### DIFF
--- a/_build/build.php
+++ b/_build/build.php
@@ -465,6 +465,96 @@ class modExtraPackage
 
 
     /**
+     * Add access policy
+     */
+    protected function policies()
+    {
+        /** @noinspection PhpIncludeInspection */
+        $policies = include($this->config['elements'] . 'policies.php');
+        if (!is_array($policies)) {
+            $this->modx->log(modX::LOG_LEVEL_ERROR, 'Could not package in Access Policies');
+            return;
+        }
+        $attributes = [
+            xPDOTransport::PRESERVE_KEYS => false,
+            xPDOTransport::UNIQUE_KEY => array('name'),
+            xPDOTransport::UPDATE_OBJECT => !empty($this->config['update']['policies']),
+        ];
+        foreach ($policies as $name => $data) {
+            if (isset($data['data'])) {
+                $data['data'] = json_encode($data['data']);
+            }
+            /** @var $policy modAccessPolicy */
+            $policy = $this->modx->newObject('modAccessPolicy');
+            $policy->fromArray(array_merge(array(
+                    'name' => $name,
+                    'lexicon' => $this->config['name_lower'] . ':permissions',
+                ), $data)
+                , '', true, true);
+            $vehicle = $this->builder->createVehicle($policy, $attributes);
+            $this->builder->putVehicle($vehicle);
+        }
+        $this->modx->log(modX::LOG_LEVEL_INFO, 'Packaged in ' . count($policies) . ' Access Policies');
+    }
+
+
+    /**
+     * Add policy templates
+     */
+    protected function policy_templates()
+    {
+        /** @noinspection PhpIncludeInspection */
+        $policy_templates = include($this->config['elements'] . 'policy_templates.php');
+        if (!is_array($policy_templates)) {
+            $this->modx->log(modX::LOG_LEVEL_ERROR, 'Could not package in Policy Templates');
+            return;
+        }
+        $attributes = [
+            xPDOTransport::PRESERVE_KEYS => false,
+            xPDOTransport::UNIQUE_KEY => array('name'),
+            xPDOTransport::UPDATE_OBJECT => !empty($this->config['update']['policy_templates']),
+            xPDOTransport::RELATED_OBJECTS => true,
+            xPDOTransport::RELATED_OBJECT_ATTRIBUTES => array(
+                'Permissions' => array(
+                    xPDOTransport::PRESERVE_KEYS => false,
+                    xPDOTransport::UPDATE_OBJECT => !empty($this->config['update']['permission']),
+                    xPDOTransport::UNIQUE_KEY => array('template', 'name'),
+                ),
+            ),
+        ];
+        foreach ($policy_templates as $name => $data) {
+            $permissions = array();
+            if (isset($data['permissions']) && is_array($data['permissions'])) {
+                foreach ($data['permissions'] as $name2 => $data2) {
+                    /** @var $permission modAccessPermission */
+                    $permission = $this->modx->newObject('modAccessPermission');
+                    $permission->fromArray(array_merge(array(
+                            'name' => $name2,
+                            'description' => $name2,
+                            'value' => true,
+                        ), $data2)
+                        , '', true, true);
+                    $permissions[] = $permission;
+                }
+            }
+            /** @var $permission modAccessPolicyTemplate */
+            $permission = $this->modx->newObject('modAccessPolicyTemplate');
+            $permission->fromArray(array_merge(array(
+                    'name' => $name,
+                    'lexicon' => $this->config['name_lower'] . ':permissions',
+                ), $data)
+                , '', true, true);
+            if (!empty($permissions)) {
+                $permission->addMany($permissions);
+            }
+            $vehicle = $this->builder->createVehicle($permission, $attributes);
+            $this->builder->putVehicle($vehicle);
+        }
+        $this->modx->log(modX::LOG_LEVEL_INFO, 'Packaged in ' . count($policy_templates) . ' Access Policy Templates');
+    }
+
+
+    /**
      * @param $filename
      *
      * @return string

--- a/_build/config.inc.php
+++ b/_build/config.inc.php
@@ -19,7 +19,10 @@ return [
     'update' => [
         'chunks' => false,
         'menus' => true,
+        'permission' => true,
         'plugins' => true,
+        'policies' => true,
+        'policy_templates' => true,
         'resources' => false,
         'settings' => false,
         'snippets' => true,

--- a/_build/elements/_policies.php
+++ b/_build/elements/_policies.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'modExtraUserPolicy' => [
+        'description' => 'modExtra policy description.',
+        'data' => [
+            'modextra_save' => true,
+        ]
+    ],
+];

--- a/_build/elements/_policy_templates.php
+++ b/_build/elements/_policy_templates.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'modExtraUserPolicyTemplate' => [
+        'description' => 'modExtra policy template description.',
+        'template_group' => 1,
+        'permissions' => [
+            'modextra_save' => [],
+        ]
+    ],
+];

--- a/_build/resolvers/_policy.php
+++ b/_build/resolvers/_policy.php
@@ -1,0 +1,27 @@
+<?php
+/** @var xPDOTransport $transport */
+/** @var array $options */
+/** @var modX $modx */
+if ($transport->xpdo) {
+    $modx =& $transport->xpdo;
+    switch ($options[xPDOTransport::PACKAGE_ACTION]) {
+        case xPDOTransport::ACTION_INSTALL:
+        case xPDOTransport::ACTION_UPGRADE:
+            // Assign policy to template
+            if ($policy = $modx->getObject('modAccessPolicy', array('name' => 'modExtraUserPolicy'))) {
+                if ($template = $modx->getObject('modAccessPolicyTemplate',
+                    array('name' => 'modExtraUserPolicyTemplate'))
+                ) {
+                    $policy->set('template', $template->get('id'));
+                    $policy->save();
+                } else {
+                    $modx->log(xPDO::LOG_LEVEL_ERROR,
+                        '[modExtra] Could not find modExtraUserPolicyTemplate Access Policy Template!');
+                }
+            } else {
+                $modx->log(xPDO::LOG_LEVEL_ERROR, '[modExtra] Could not find modExtraUserPolicyTemplate Access Policy!');
+            }
+            break;
+    }
+}
+return true;

--- a/core/components/modextra/lexicon/en/permissions.inc.php
+++ b/core/components/modextra/lexicon/en/permissions.inc.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Russian permissions Lexicon Entries for modExtra
+ *
+ * @package modExtra
+ * @subpackage lexicon
+ */
+$_lang['modextra_save'] = 'Permission for save/update data.';

--- a/core/components/modextra/lexicon/ru/permissions.inc.php
+++ b/core/components/modextra/lexicon/ru/permissions.inc.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * English permissions Lexicon Entries for modExtra
+ *
+ * @package modExtra
+ * @subpackage lexicon
+ */
+$_lang['modextra_save'] = 'Разрешает создание/изменение данных.';


### PR DESCRIPTION
Добавил возможность из "коробки" добавления "Шаблоны политик доступа" и "Политики доступа". По умолчанию настройки контроля доступа добавляться не будут, т.к. файлы элементов и ресолвера переименованы "с подчеркиванием". Теперь, в случае, если человек пишет компонент, который требует добавление настроек доступа, то ему достаточно переименовать файлы, заполнить массивы и словари. Экономия времени)

PS Взято с Tickets.