### PR TITLE
Adding subcategories to the main category

### DIFF
--- a/_build/build.php
+++ b/_build/build.php
@@ -555,6 +555,38 @@ class modExtraPackage
 
 
     /**
+     * Add categories
+     */
+    protected function categories()
+    {
+        /** @noinspection PhpIncludeInspection */
+        $categories = include($this->config['elements'] . 'categories.php');
+        if (!is_array($categories)) {
+            $this->modx->log(modX::LOG_LEVEL_ERROR, 'Could not package in Categories');
+
+            return;
+        }
+        $this->category_attributes[xPDOTransport::RELATED_OBJECT_ATTRIBUTES]['Children'] = [
+            xPDOTransport::UNIQUE_KEY => 'category',
+            xPDOTransport::PRESERVE_KEYS => false,
+            xPDOTransport::UPDATE_OBJECT => !empty($this->config['update']['categories']),
+            xPDOTransport::RELATED_OBJECTS => true,
+            xPDOTransport::RELATED_OBJECT_ATTRIBUTES => [],
+        ];
+        $objects = [];
+        foreach ($categories as $name => $data) {
+            /** @var modCategory[] $objects */
+            $objects[$name] = $this->modx->newObject('modCategory');
+            $objects[$name]->fromArray(array_merge([
+                'category' => $name,
+            ], $data), '', true, true);
+        }
+        $this->category->addMany($objects, 'Children');
+        $this->modx->log(modX::LOG_LEVEL_INFO, 'Packaged in ' . count($objects) . ' Categories');
+    }
+
+
+    /**
      * @param $filename
      *
      * @return string

--- a/_build/config.inc.php
+++ b/_build/config.inc.php
@@ -17,6 +17,7 @@ return [
     'install' => true,
     // Which elements should be updated on package upgrade
     'update' => [
+        'categories' => true,
         'chunks' => false,
         'menus' => true,
         'permission' => true,

--- a/_build/elements/_categories.php
+++ b/_build/elements/_categories.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'modExtraCategoryExample' => [],
+];


### PR DESCRIPTION
Добавлена возможность из "коробки" создания категорий, помимо основной. Все категории создаются дочерними к основной категории для однообразия реализации (в ресолверах потом каждый под себя может раскидать их по необходимой вложенности).
Пример http://joxi.ru/eAOYKnBc97Qzym.