### PR TITLE
Fix clear cache action

### DIFF
--- a/_build/build.php
+++ b/_build/build.php
@@ -664,7 +664,13 @@ class modExtraPackage
             $package->save();
         }
         if ($package->install()) {
-            $this->modx->runProcessor('system/clearcache');
+            $action = 'system/clearcache';
+
+            if ($this->modx->getVersionData()['version'] === 3) {
+                $action = 'System/ClearCache';
+            }
+
+            $this->modx->runProcessor($action);
         }
     }
 


### PR DESCRIPTION
### Что оно делает?

Исправляет ошибку очистки кеша на MODX 3

### Зачем это нужно?

В modx 3 переименовали экшон очистки кеша, по этому сборка компонента падает в ошибку
