### PR TITLE
Add requeries

### DIFF
--- a/_build/build.php
+++ b/_build/build.php
@@ -733,6 +733,12 @@ class modExtraPackage
             'changelog' => file_get_contents($this->config['core'] . 'docs/changelog.txt'),
             'license' => file_get_contents($this->config['core'] . 'docs/license.txt'),
             'readme' => file_get_contents($this->config['core'] . 'docs/readme.txt'),
+            'requires' => [
+                'php' => '>=7.0.0',
+                'modx' => '<3.0.0',
+                //'MIGX' => '>=1.0.0', //Example add package
+                //'translit' => '>=1.0.0-beta', //Example add package
+            ],
         ]);
         $this->modx->log(modX::LOG_LEVEL_INFO, 'Added package attributes and setup options.');
 


### PR DESCRIPTION
Добавил зависимости, что бы наглядно было видно, как их добавлять

### Что оно делает?

Добавляет возможность указывать нужные зависимости

### Зачем это нужно?

Что бы нельзя было установить пакет, если нужны какие либо дополнительные пакеты, версия MODX или PHP

